### PR TITLE
Automatically build before analysis

### DIFF
--- a/.github/workflows/shiftleft-analysis.yml
+++ b/.github/workflows/shiftleft-analysis.yml
@@ -23,6 +23,7 @@ jobs:
       env:
         WORKSPACE: ""
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        SCAN_AUTO_BUILD: true
       with:
         output: reports
         # Scan auto-detects the languages in your project. To override uncomment the below variable and set the type


### PR DESCRIPTION
Thank you for trying ShiftLeft Scan. I noticed that the workflow was not compiling the project resulting in 0 findings from scan. This PR enables automatic build which would help scan with a thorough analysis.